### PR TITLE
feat: migrate to nested skilljar: YAML front matter (v0.2.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: quarjar
 Title: Publish Quarto Content to Skilljar
-Version: 0.1.0
+Version: 0.2.0
 Authors@R:
     person("François Michonneau", email = "francois.michonneau@posit.co", role = c("aut", "cre"))
 Description: Tools for publishing Quarto-rendered HTML content to Skilljar lessons via the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,31 @@
+# quarjar 0.2.0
+
+## Breaking changes (with backward compatibility)
+
+* Front matter keys are now nested under a single `skilljar:` block instead of
+  using flat `skilljar_*` prefixed keys. The old flat keys continue to work but
+  emit a deprecation warning. Migrate your `.qmd` files:
+
+  **Before:**
+  ```yaml
+  skilljar_course_id: "abc123"
+  skilljar_lesson_order: 0
+  display_fullscreen: true
+  ```
+
+  **After:**
+  ```yaml
+  skilljar:
+    course_id: "abc123"
+    lesson_order: 0
+    display_fullscreen: true
+  ```
+
+## New features
+
+* Added `parse_skilljar_fm()` (internal helper) for centralised YAML front
+  matter validation with type coercion and unknown-key detection.
+* `display_fullscreen` is now documented as a supported front matter key under
+  `skilljar.display_fullscreen`.
+* `ci_write_lesson_id()` now patches the `skilljar:` block in place rather
+  than appending a bare top-level key.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# quarjar (development)
+
+## Breaking changes
+
+* Flat `skilljar_*` front matter keys no longer emit a deprecation warning —
+  they now abort with a migration error. Files using the old format will
+  fail immediately with an actionable message pointing to the README.
+
+## New features
+
+* Workflow version check: the GitHub Actions workflow now warns (non-blocking)
+  at runtime when the workflow template version does not match the installed
+  `quarjar` package version.
+* Post-writeback YAML validation: after the workflow commits `skilljar.lesson_id`
+  back to `main`, a new step re-parses the front matter and confirms the field
+  is present and the YAML is still valid.
+
+## Bug fixes / test coverage
+
+* Added test for `ci_write_lesson_id()` when `skilljar:` is the last front
+  matter line (empty block, `seq_len(0)` edge case).
+
 # quarjar 0.2.0
 
 ## Breaking changes (with backward compatibility)

--- a/R/ci.R
+++ b/R/ci.R
@@ -535,7 +535,8 @@ ci_write_lesson_id <- function(
     # Find the extent of the skilljar: block (contiguous indented lines after it).
     sj_start  <- sj_line[1]
     block_end <- sj_start
-    for (i in seq(sj_start + 1L, length(fm_lines))) {
+    remaining <- seq_len(length(fm_lines) - sj_start) + sj_start
+    for (i in remaining) {
       if (grepl("^  ", fm_lines[i])) {
         block_end <- i
       } else {

--- a/R/ci.R
+++ b/R/ci.R
@@ -24,29 +24,18 @@
 parse_skilljar_fm <- function(fm) {
   sj <- fm[["skilljar"]]
 
-  # --- Backward-compat shim: flat keys ---
-  # If there is no `skilljar:` block but the old flat keys are present,
-  # warn and promote them into the nested structure so the rest of the
-  # pipeline keeps working.
+  # Flat keys are no longer supported — abort with a migration hint.
   flat_present <- any(c("skilljar_course_id", "skilljar_package_title",
                         "skilljar_lesson_order", "skilljar_lesson_id",
                         "display_fullscreen") %in% names(fm))
   if (is.null(sj) && flat_present) {
-    cli::cli_warn(c(
-      "Flat {.field skilljar_*} front matter keys are deprecated.",
-      "i" = "Please migrate to the nested {.field skilljar:} block:",
+    cli::cli_abort(c(
+      "This file uses the deprecated flat {.field skilljar_*} front matter format.",
+      "i" = "Migrate to the nested {.field skilljar:} block:",
       "i" = "skilljar:",
       "i" = "  course_id: \"<your-course-id>\"",
-      "i" = "See the quarjar README for the full schema."
+      "i" = "See the quarjar README for instructions."
     ))
-    sj <- list(
-      course_id          = fm[["skilljar_course_id"]],
-      package_title      = fm[["skilljar_package_title"]],
-      lesson_order       = fm[["skilljar_lesson_order"]],
-      lesson_id          = fm[["skilljar_lesson_id"]],
-      display_fullscreen = fm[["display_fullscreen"]]
-    )
-    sj <- Filter(Negate(is.null), sj)
   }
 
   if (is.null(sj)) return(NULL)
@@ -519,9 +508,8 @@ ci_write_lesson_id <- function(
 
   fm_lines <- lines[seq(sep_idx[1] + 1L, sep_idx[2] - 1L)]
 
-  # Idempotency: bail out if lesson_id already recorded under either scheme.
-  if (any(grepl("^  lesson_id:", fm_lines)) ||
-      any(grepl("^skilljar_lesson_id:", fm_lines))) {
+  # Idempotency: bail out if lesson_id already recorded.
+  if (any(grepl("^  lesson_id:", fm_lines))) {
     cli::cli_alert_info(
       "lesson_id already present in {qmd_file} - no changes written"
     )
@@ -553,15 +541,11 @@ ci_write_lesson_id <- function(
       lines[seq(insert_after + 1L, length(lines))]
     )
   } else {
-    # No skilljar: block — fall back to appending a flat top-level key (old scheme).
-    cli::cli_warn(
-      "No {.field skilljar:} block found; writing flat {.field skilljar_lesson_id} key. Consider migrating to the nested syntax."
-    )
-    new_lines <- c(
-      lines[seq_len(sep_idx[2] - 1L)],
-      paste0('skilljar_lesson_id: "', lesson_id, '"'),
-      lines[seq(sep_idx[2], length(lines))]
-    )
+    cli::cli_abort(c(
+      "No {.field skilljar:} block found in {.file {qmd_file}}.",
+      "i" = "Migrate the front matter to the nested {.field skilljar:} format before publishing.",
+      "i" = "See the quarjar README for instructions."
+    ))
   }
 
   writeLines(new_lines, qmd_file)

--- a/R/ci.R
+++ b/R/ci.R
@@ -63,14 +63,17 @@ parse_skilljar_fm <- function(fm) {
 
   # course_id — required, must be non-empty character
   course_id <- sj[["course_id"]]
-  if (is.null(course_id) || !nzchar(as.character(course_id))) {
-    cli::cli_abort("{.field skilljar.course_id} is required but missing or empty.")
+  if (is.null(course_id)) {
+    cli::cli_abort("{.field skilljar.course_id} is required but missing.")
   }
   if (!is.character(course_id)) {
     cli::cli_abort(c(
       "{.field skilljar.course_id} must be a character string.",
       "i" = "Got {.cls {class(course_id)}}. Did a leading zero get stripped?"
     ))
+  }
+  if (!nzchar(course_id)) {
+    cli::cli_abort("{.field skilljar.course_id} is required but empty.")
   }
 
   # package_title — optional character

--- a/R/ci.R
+++ b/R/ci.R
@@ -18,6 +18,102 @@
 }
 
 
+# Internal helper: validate and type-coerce the `skilljar:` front matter block.
+# Returns NULL if the `skilljar` key is absent (file should be skipped).
+# Aborts or warns on bad values.
+parse_skilljar_fm <- function(fm) {
+  sj <- fm[["skilljar"]]
+
+  # --- Backward-compat shim: flat keys ---
+  # If there is no `skilljar:` block but the old flat keys are present,
+  # warn and promote them into the nested structure so the rest of the
+  # pipeline keeps working.
+  flat_present <- any(c("skilljar_course_id", "skilljar_package_title",
+                        "skilljar_lesson_order", "skilljar_lesson_id",
+                        "display_fullscreen") %in% names(fm))
+  if (is.null(sj) && flat_present) {
+    cli::cli_warn(c(
+      "Flat {.field skilljar_*} front matter keys are deprecated.",
+      "i" = "Please migrate to the nested {.field skilljar:} block:",
+      "i" = "skilljar:",
+      "i" = "  course_id: \"<your-course-id>\"",
+      "i" = "See the quarjar README for the full schema."
+    ))
+    sj <- list(
+      course_id          = fm[["skilljar_course_id"]],
+      package_title      = fm[["skilljar_package_title"]],
+      lesson_order       = fm[["skilljar_lesson_order"]],
+      lesson_id          = fm[["skilljar_lesson_id"]],
+      display_fullscreen = fm[["display_fullscreen"]]
+    )
+    sj <- Filter(Negate(is.null), sj)
+  }
+
+  if (is.null(sj)) return(NULL)
+
+  # Unknown-key detection (typo guard)
+  known_keys <- c("course_id", "package_title", "lesson_order",
+                  "lesson_id", "display_fullscreen")
+  unknown <- setdiff(names(sj), known_keys)
+  if (length(unknown) > 0) {
+    cli::cli_warn(
+      "Unknown key(s) inside {.field skilljar:}: {.field {unknown}}. Possible typo?"
+    )
+  }
+
+  # course_id — required, must be non-empty character
+  course_id <- sj[["course_id"]]
+  if (is.null(course_id) || !nzchar(as.character(course_id))) {
+    cli::cli_abort("{.field skilljar.course_id} is required but missing or empty.")
+  }
+  if (!is.character(course_id)) {
+    cli::cli_abort(c(
+      "{.field skilljar.course_id} must be a character string.",
+      "i" = "Got {.cls {class(course_id)}}. Did a leading zero get stripped?"
+    ))
+  }
+
+  # package_title — optional character
+  package_title <- as.character(rlang::`%||%`(sj[["package_title"]], ""))
+
+  # lesson_order — optional, must be integerish if present
+  lesson_order <- sj[["lesson_order"]]
+  if (!is.null(lesson_order)) {
+    coerced <- suppressWarnings(as.integer(lesson_order))
+    if (is.na(coerced)) {
+      cli::cli_abort(
+        "{.field skilljar.lesson_order} must be an integer, got {.val {lesson_order}}."
+      )
+    }
+    lesson_order <- coerced
+  }
+
+  # lesson_id — optional character
+  lesson_id <- as.character(rlang::`%||%`(sj[["lesson_id"]], ""))
+
+  # display_fullscreen — optional logical, default TRUE
+  display_fullscreen_raw <- rlang::`%||%`(sj[["display_fullscreen"]], NULL)
+  if (is.null(display_fullscreen_raw)) {
+    display_fullscreen <- TRUE
+  } else if (is.logical(display_fullscreen_raw)) {
+    display_fullscreen <- display_fullscreen_raw
+  } else {
+    cli::cli_warn(
+      "{.field skilljar.display_fullscreen} should be {.code true} or {.code false}; coercing."
+    )
+    display_fullscreen <- isTRUE(display_fullscreen_raw)
+  }
+
+  list(
+    course_id          = course_id,
+    package_title      = package_title,
+    lesson_order       = lesson_order,
+    lesson_id          = lesson_id,
+    display_fullscreen = display_fullscreen
+  )
+}
+
+
 #' Generate a timestamped ZIP package (CI helper)
 #'
 #' Renders a Quarto document, appends a timestamp to the ZIP filename for

--- a/R/ci.R
+++ b/R/ci.R
@@ -466,15 +466,14 @@ ci_delete_old_web_package <- function(
 
 #' Inject Skilljar lesson ID into QMD front matter (CI helper)
 #'
-#' Reads a Quarto document, appends \code{skilljar_lesson_id} to the YAML
-#' front matter (if not already present), and writes the file back in place.
-#' This replaces the Python front-matter-patching script used in the
-#' "Write lesson ID back to main" workflow step, eliminating the Python
-#' dependency for that step.
+#' Reads a Quarto document and inserts \code{lesson_id} inside the nested
+#' \code{skilljar:} front matter block.  Falls back to appending a flat
+#' \code{skilljar_lesson_id:} top-level key when no \code{skilljar:} block is
+#' present (backward compatibility for repos that haven't migrated yet).
 #'
-#' The function exits silently (returning \code{FALSE}) if
-#' \code{skilljar_lesson_id} is already present, so it is safe to call
-#' idempotently.
+#' The function exits silently (returning \code{FALSE}) if either
+#' \code{skilljar.lesson_id} (nested) or \code{skilljar_lesson_id} (flat) is
+#' already present, so it is safe to call idempotently.
 #'
 #' @section Environment variables:
 #' \describe{
@@ -486,12 +485,10 @@ ci_delete_old_web_package <- function(
 #' @param lesson_id Character. Skilljar lesson ID to inject.
 #'
 #' @return Invisibly returns \code{TRUE} if the file was modified,
-#'   \code{FALSE} if \code{skilljar_lesson_id} was already present (file
-#'   left unchanged).
+#'   \code{FALSE} if the lesson ID was already present (file left unchanged).
 #'
 #' @examples
 #' \dontrun{
-#' # In a GitHub Actions step (shell: Rscript {0}):
 #' library(quarjar)
 #' ci_write_lesson_id()
 #' }
@@ -513,7 +510,7 @@ ci_write_lesson_id <- function(
     rlang::abort(paste("File not found:", qmd_file))
   }
 
-  lines <- readLines(qmd_file, warn = FALSE)
+  lines   <- readLines(qmd_file, warn = FALSE)
   sep_idx <- which(grepl("^---\\s*$", lines))
 
   if (length(sep_idx) < 2) {
@@ -522,21 +519,51 @@ ci_write_lesson_id <- function(
 
   fm_lines <- lines[seq(sep_idx[1] + 1L, sep_idx[2] - 1L)]
 
-  if (any(grepl("^skilljar_lesson_id:", fm_lines))) {
+  # Idempotency: bail out if lesson_id already recorded under either scheme.
+  if (any(grepl("^  lesson_id:", fm_lines)) ||
+      any(grepl("^skilljar_lesson_id:", fm_lines))) {
     cli::cli_alert_info(
-      "skilljar_lesson_id already present in {qmd_file} - no changes written"
+      "lesson_id already present in {qmd_file} - no changes written"
     )
     return(invisible(FALSE))
   }
 
-  # Append the new field just before the closing ---
-  new_lines <- c(
-    lines[seq_len(sep_idx[2] - 1L)],
-    paste0('skilljar_lesson_id: "', lesson_id, '"'),
-    lines[seq(sep_idx[2], length(lines))]
-  )
+  # Locate the `skilljar:` block and find the last indented line in it.
+  sj_line <- which(grepl("^skilljar:\\s*$", fm_lines))
+
+  if (length(sj_line) > 0) {
+    # Find the extent of the skilljar: block (contiguous indented lines after it).
+    sj_start  <- sj_line[1]
+    block_end <- sj_start
+    for (i in seq(sj_start + 1L, length(fm_lines))) {
+      if (grepl("^  ", fm_lines[i])) {
+        block_end <- i
+      } else {
+        break
+      }
+    }
+
+    # Insert `  lesson_id: "..."` right after the last line of the block.
+    insert_after <- sep_idx[1] + block_end  # absolute line index
+    new_line     <- paste0('  lesson_id: "', lesson_id, '"')
+    new_lines    <- c(
+      lines[seq_len(insert_after)],
+      new_line,
+      lines[seq(insert_after + 1L, length(lines))]
+    )
+  } else {
+    # No skilljar: block — fall back to appending a flat top-level key (old scheme).
+    cli::cli_warn(
+      "No {.field skilljar:} block found; writing flat {.field skilljar_lesson_id} key. Consider migrating to the nested syntax."
+    )
+    new_lines <- c(
+      lines[seq_len(sep_idx[2] - 1L)],
+      paste0('skilljar_lesson_id: "', lesson_id, '"'),
+      lines[seq(sep_idx[2], length(lines))]
+    )
+  }
 
   writeLines(new_lines, qmd_file)
-  cli::cli_alert_success("Wrote skilljar_lesson_id to {qmd_file}")
+  cli::cli_alert_success("Wrote lesson_id to {qmd_file}")
   invisible(TRUE)
 }

--- a/R/ci.R
+++ b/R/ci.R
@@ -456,13 +456,12 @@ ci_delete_old_web_package <- function(
 #' Inject Skilljar lesson ID into QMD front matter (CI helper)
 #'
 #' Reads a Quarto document and inserts \code{lesson_id} inside the nested
-#' \code{skilljar:} front matter block.  Falls back to appending a flat
-#' \code{skilljar_lesson_id:} top-level key when no \code{skilljar:} block is
-#' present (backward compatibility for repos that haven't migrated yet).
+#' \code{skilljar:} front matter block.  Aborts if no \code{skilljar:} block is
+#' present — the file must be migrated to the nested format first.
 #'
-#' The function exits silently (returning \code{FALSE}) if either
-#' \code{skilljar.lesson_id} (nested) or \code{skilljar_lesson_id} (flat) is
-#' already present, so it is safe to call idempotently.
+#' The function exits silently (returning \code{FALSE}) if
+#' \code{skilljar.lesson_id} is already present, so it is safe to call
+#' idempotently.
 #'
 #' @section Environment variables:
 #' \describe{

--- a/R/use_skilljar_workflow.R
+++ b/R/use_skilljar_workflow.R
@@ -37,21 +37,21 @@
 #'
 #' All workflow configuration is driven by YAML front matter in your `.qmd`
 #' files. The workflow scans every changed `.qmd` file on push and reads the
-#' following keys:
+#' following keys inside a single nested `skilljar:` block:
 #'
 #' \describe{
-#'   \item{`skilljar_course_id`}{**Required.** The Skilljar course ID to publish
-#'     the lesson to. Files without this key are silently skipped by the
-#'     workflow.}
+#'   \item{`skilljar.course_id`}{**Required.** The Skilljar course ID to
+#'     publish the lesson to. Files without this key are silently skipped.}
 #'   \item{`title`}{The lesson title in Skilljar. Uses the standard Quarto
-#'     `title` field (not `skilljar_`-prefixed).}
-#'   \item{`skilljar_package_title`}{*(Optional)* Title for the Skilljar web
-#'     package. Defaults to the value of `title` when omitted.}
-#'   \item{`skilljar_lesson_order`}{*(Optional)* Zero-based integer that sets
+#'     `title` field (not nested under `skilljar:`).}
+#'   \item{`skilljar.package_title`}{*(Optional)* Title for the Skilljar web
+#'     package. Defaults to `title` when omitted.}
+#'   \item{`skilljar.lesson_order`}{*(Optional)* Zero-based integer that sets
 #'     the lesson's position in the course syllabus on **first publish only**.
-#'     Ignored on subsequent updates. When omitted, the next available order is
-#'     detected automatically.}
-#'   \item{`skilljar_lesson_id`}{The Skilljar lesson ID. **Do not set this
+#'     Ignored on updates. Auto-detected when omitted.}
+#'   \item{`skilljar.display_fullscreen`}{*(Optional)* Logical. Whether the
+#'     lesson iframe is displayed full-screen in Skilljar. Defaults to `true`.}
+#'   \item{`skilljar.lesson_id`}{The Skilljar lesson ID. **Do not set this
 #'     manually.** After the first successful publish the workflow commits this
 #'     value back to `main` (tagged `[skip ci]`), switching future runs to the
 #'     update-existing-lesson path.}
@@ -62,7 +62,8 @@
 #' ```yaml
 #' ---
 #' title: "My Lesson Title"
-#' skilljar_course_id: "abc123"
+#' skilljar:
+#'   course_id: "abc123"
 #' ---
 #' ```
 #'
@@ -71,11 +72,18 @@
 #' ```yaml
 #' ---
 #' title: "Module 1: Getting Started"
-#' skilljar_course_id: "abc123"
-#' skilljar_package_title: "Module 1 Package"
-#' skilljar_lesson_order: 0
+#' skilljar:
+#'   course_id: "abc123"
+#'   package_title: "Module 1 Package"
+#'   lesson_order: 0
+#'   display_fullscreen: true
 #' ---
 #' ```
+#'
+#' **Deprecated flat keys:** `skilljar_course_id`, `skilljar_package_title`,
+#' `skilljar_lesson_order`, `skilljar_lesson_id`, and `display_fullscreen` as
+#' top-level keys still work but will emit a deprecation warning at publish
+#' time. Migrate to the nested `skilljar:` block at your earliest convenience.
 #'
 #' For complete setup instructions and troubleshooting, see the
 #' [setup guide](https://github.com/posit-dev/quarjar/blob/main/examples/GITHUB_ACTION_SETUP.md).

--- a/R/use_skilljar_workflow.R
+++ b/R/use_skilljar_workflow.R
@@ -29,22 +29,56 @@
 #' \enumerate{
 #'   \item Enable GitHub Pages in your repository (Settings → Pages → Deploy from `gh-pages` branch)
 #'   \item Add your Skilljar API key as a repository secret named `SKILLJAR_API_KEY`
+#'   \item Add a fine-grained PAT with Contents and Pages read/write as a repository secret named `REPO_PAT`
 #'   \item Set repository permissions to "Read and write" (Settings → Actions → General)
 #' }
 #'
-#' **Usage:**
+#' **Quarto Front Matter Keys:**
 #'
-#' After running this function, trigger the workflow from the Actions tab in your
-#' GitHub repository with the following inputs:
-#' \itemize{
-#'   \item `qmd-file`: Path to your Quarto (.qmd) file
-#'   \item `course-id`: Your Skilljar course ID
-#'   \item `lesson-title`: Title for the lesson
-#'   \item `package-title`: (optional) Title for the web package
+#' All workflow configuration is driven by YAML front matter in your `.qmd`
+#' files. The workflow scans every changed `.qmd` file on push and reads the
+#' following keys:
+#'
+#' \describe{
+#'   \item{`skilljar_course_id`}{**Required.** The Skilljar course ID to publish
+#'     the lesson to. Files without this key are silently skipped by the
+#'     workflow.}
+#'   \item{`title`}{The lesson title in Skilljar. Uses the standard Quarto
+#'     `title` field (not `skilljar_`-prefixed).}
+#'   \item{`skilljar_package_title`}{*(Optional)* Title for the Skilljar web
+#'     package. Defaults to the value of `title` when omitted.}
+#'   \item{`skilljar_lesson_order`}{*(Optional)* Zero-based integer that sets
+#'     the lesson's position in the course syllabus on **first publish only**.
+#'     Ignored on subsequent updates. When omitted, the next available order is
+#'     detected automatically.}
+#'   \item{`skilljar_lesson_id`}{The Skilljar lesson ID. **Do not set this
+#'     manually.** After the first successful publish the workflow commits this
+#'     value back to `main` (tagged `[skip ci]`), switching future runs to the
+#'     update-existing-lesson path.}
 #' }
 #'
+#' A minimal front matter example:
+#'
+#' ```yaml
+#' ---
+#' title: "My Lesson Title"
+#' skilljar_course_id: "abc123"
+#' ---
+#' ```
+#'
+#' A fully configured example:
+#'
+#' ```yaml
+#' ---
+#' title: "Module 1: Getting Started"
+#' skilljar_course_id: "abc123"
+#' skilljar_package_title: "Module 1 Package"
+#' skilljar_lesson_order: 0
+#' ---
+#' ```
+#'
 #' For complete setup instructions and troubleshooting, see the
-#' [setup guide](https://github.com/posit-dev/quarjar/blob/main/GITHUB_ACTION_SETUP.md).
+#' [setup guide](https://github.com/posit-dev/quarjar/blob/main/examples/GITHUB_ACTION_SETUP.md).
 #'
 #' @examples
 #' \dontrun{

--- a/README.md
+++ b/README.md
@@ -427,19 +427,36 @@ Steps 1–5 run identically, then:
 
 #### Front Matter Configuration
 
-All workflow configuration lives in your `.qmd` front matter — no workflow inputs needed:
+All workflow configuration lives in your `.qmd` front matter — no workflow inputs needed.
+The workflow scans every changed `.qmd` file on push and reads the following keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `title` | Yes | Lesson title in Skilljar. Uses the standard Quarto `title` field. |
+| `skilljar_course_id` | **Required** | Skilljar course ID to publish to. Files without this key are silently skipped. |
+| `skilljar_package_title` | Optional | Title for the Skilljar web package. Defaults to `title` when omitted. |
+| `skilljar_lesson_order` | Optional | Zero-based integer position in the course syllabus. Applied on first publish only; ignored on updates. Auto-detected when omitted. |
+| `skilljar_lesson_id` | — | **Do not set manually.** Committed back to `main` (tagged `[skip ci]`) by the workflow after the first successful publish, switching future runs to the update-existing-lesson path. |
+
+Minimal example:
 
 ```yaml
 ---
-title: "My Lesson Title"           # used as the lesson title in Skilljar
-skilljar_course_id: "abc123"       # required — files without this are skipped
-skilljar_package_title: "..."      # optional; defaults to title
-skilljar_lesson_order: 3           # optional; explicit position in course (create only)
-skilljar_lesson_id: "xyz789"       # committed directly to main after first publish
+title: "My Lesson Title"
+skilljar_course_id: "abc123"
 ---
 ```
 
-`skilljar_lesson_id` is never set manually. The workflow commits it directly to `main` (with `[skip ci]`) after the first successful publish, activating the update-on-push path for future runs.
+Fully configured example:
+
+```yaml
+---
+title: "Module 1: Getting Started"
+skilljar_course_id: "abc123"
+skilljar_package_title: "Module 1 Package"
+skilljar_lesson_order: 0
+---
+```
 
 To re-trigger a failed run, make a trivial change to the `.qmd` file (the
 `paths` filter requires at least one `.qmd` to be modified — an empty commit

--- a/README.md
+++ b/README.md
@@ -430,20 +430,27 @@ Steps 1–5 run identically, then:
 All workflow configuration lives in your `.qmd` front matter — no workflow inputs needed.
 The workflow scans every changed `.qmd` file on push and reads the following keys:
 
-| Key | Required | Description |
+| Key | Required? | Description |
 |-----|----------|-------------|
-| `title` | Yes | Lesson title in Skilljar. Uses the standard Quarto `title` field. |
-| `skilljar_course_id` | **Required** | Skilljar course ID to publish to. Files without this key are silently skipped. |
-| `skilljar_package_title` | Optional | Title for the Skilljar web package. Defaults to `title` when omitted. |
-| `skilljar_lesson_order` | Optional | Zero-based integer position in the course syllabus. Applied on first publish only; ignored on updates. Auto-detected when omitted. |
-| `skilljar_lesson_id` | — | **Do not set manually.** Committed back to `main` (tagged `[skip ci]`) by the workflow after the first successful publish, switching future runs to the update-existing-lesson path. |
+| `title` | Yes | Lesson title in Skilljar. Standard Quarto `title` field (not nested). |
+| `skilljar.course_id` | **Required** | Skilljar course ID to publish to. Files without this key are silently skipped. |
+| `skilljar.package_title` | Optional | Title for the Skilljar web package. Defaults to `title` when omitted. |
+| `skilljar.lesson_order` | Optional | Zero-based integer position in the course syllabus. Applied on first publish only; ignored on updates. Auto-detected when omitted. |
+| `skilljar.display_fullscreen` | Optional | Whether the lesson iframe is displayed full-screen. Default `true`. |
+| `skilljar.lesson_id` | — | **Do not set manually.** Committed back to `main` (tagged `[skip ci]`) after first publish. |
+
+> **Deprecated:** The flat `skilljar_course_id`, `skilljar_package_title`,
+> `skilljar_lesson_order`, `skilljar_lesson_id`, and top-level
+> `display_fullscreen` keys still work but emit a deprecation warning.
+> Migrate to the nested `skilljar:` block shown above.
 
 Minimal example:
 
 ```yaml
 ---
 title: "My Lesson Title"
-skilljar_course_id: "abc123"
+skilljar:
+  course_id: "abc123"
 ---
 ```
 
@@ -452,9 +459,11 @@ Fully configured example:
 ```yaml
 ---
 title: "Module 1: Getting Started"
-skilljar_course_id: "abc123"
-skilljar_package_title: "Module 1 Package"
-skilljar_lesson_order: 0
+skilljar:
+  course_id: "abc123"
+  package_title: "Module 1 Package"
+  lesson_order: 0
+  display_fullscreen: true
 ---
 ```
 
@@ -524,13 +533,14 @@ lesson <- create_lesson_with_web_package(
 )
 ```
 
-For the GitHub Actions workflow, use `skilljar_lesson_order` in the `.qmd` front matter:
+For the GitHub Actions workflow, use `skilljar.lesson_order` in the `.qmd` front matter:
 
 ```yaml
 ---
 title: "Module 1"
-skilljar_course_id: "abc123"
-skilljar_lesson_order: 2   # sets position on first publish; ignored on updates
+skilljar:
+  course_id: "abc123"
+  lesson_order: 2   # sets position on first publish; ignored on updates
 ---
 ```
 

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -69,9 +69,8 @@ jobs:
                           'display_fullscreen': bool(
                               sj.get('display_fullscreen',
                                      fm.get('display_fullscreen', True))),
-                          'lesson_order': (
-                              sj.get('lesson_order') or
-                              fm.get('skilljar_lesson_order')),
+                          'lesson_order': (sj['lesson_order'] if 'lesson_order' in sj
+                                           else fm.get('skilljar_lesson_order')),
                           'lesson_id': str(
                               sj.get('lesson_id', '') or
                               fm.get('skilljar_lesson_id', '')),

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -1,3 +1,4 @@
+# quarjar-workflow-version: 0.2.0
 name: Publish Quarto to Skilljar via GitHub Pages
 
 on:
@@ -144,6 +145,24 @@ jobs:
         run: |
           pak::pak("posit-dev/quarjar")
         shell: Rscript {0}
+
+      - name: Check workflow version
+        run: |
+          # Extract the version recorded in this workflow file.
+          WORKFLOW_VERSION=$(grep -m1 'quarjar-workflow-version:' \
+            "${GITHUB_WORKSPACE}/.github/workflows/publish-quarto-to-skilljar.yml" \
+            | sed 's/.*quarjar-workflow-version: *//')
+
+          # Get the installed quarjar package version.
+          PKG_VERSION=$(Rscript -e "cat(as.character(packageVersion('quarjar')))")
+
+          if [ -z "${WORKFLOW_VERSION}" ]; then
+            echo "::warning::quarjar: workflow version comment not found. Add '# quarjar-workflow-version: X.Y.Z' to the top of this file."
+          elif [ "${WORKFLOW_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::warning::quarjar: workflow template is version ${WORKFLOW_VERSION} but the installed quarjar package is ${PKG_VERSION}. Run quarjar::use_skilljar_workflow(overwrite = TRUE) to update the workflow."
+          else
+            echo "Workflow version ${WORKFLOW_VERSION} matches installed quarjar ${PKG_VERSION}."
+          fi
 
       - name: Generate ZIP package from Quarto
         id: generate-zip

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -50,30 +50,25 @@ jobs:
                       continue
                   fm = yaml.safe_load(parts[1]) or {}
 
-                  # Support both nested skilljar: block (new) and flat
-                  # skilljar_* keys (deprecated).  Validation/warnings for
-                  # the deprecated form happen in R (parse_skilljar_fm()).
+                  # Only the nested skilljar: block is supported.
+                  # Files with flat skilljar_* keys will produce an empty
+                  # course_id and be skipped here; the R layer will abort
+                  # with a migration message if they reach it another way.
                   sj = fm.get('skilljar', {}) or {}
-                  course_id = str(sj.get('course_id', '') or
-                                  fm.get('skilljar_course_id', '')).strip()
+                  course_id = str(sj.get('course_id', '')).strip()
 
                   if course_id:
                       items.append({
                           'qmd_file': f,
                           'course_id': course_id,
                           'lesson_title': str(fm.get('title', f)),
-                          'package_title': str(
-                              sj.get('package_title', '') or
-                              fm.get('skilljar_package_title', '')),
+                          'package_title': str(sj.get('package_title', '')),
                           'base_url': 'https://api.skilljar.com',
                           'display_fullscreen': bool(
-                              sj.get('display_fullscreen',
-                                     fm.get('display_fullscreen', True))),
+                              sj.get('display_fullscreen', True)),
                           'lesson_order': (sj['lesson_order'] if 'lesson_order' in sj
-                                           else fm.get('skilljar_lesson_order')),
-                          'lesson_id': str(
-                              sj.get('lesson_id', '') or
-                              fm.get('skilljar_lesson_id', '')),
+                                           else None),
+                          'lesson_id': str(sj.get('lesson_id', '')),
                       })
                       print(f"Added {f}: course_id={course_id!r}")
                   else:

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -334,6 +334,38 @@ jobs:
           git commit -m "chore: record Skilljar lesson ID in ${QMD_FILE} [skip ci]"
           git push origin main
 
+      - name: Validate front matter after lesson ID writeback
+        if: steps.create-or-update-lesson.outputs.is_new_lesson == 'true'
+        env:
+          QMD_FILE: ${{ matrix.qmd_file }}
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, os, re, sys
+
+          qmd_file = os.environ['QMD_FILE']
+          with open(qmd_file) as fh:
+              content = fh.read()
+
+          sep = re.compile(r'^---\s*$', re.MULTILINE)
+          parts = sep.split(content, maxsplit=2)
+          if len(parts) < 3 or parts[0].strip() != '':
+              print(f"ERROR: No YAML front matter found in {qmd_file}", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              fm = yaml.safe_load(parts[1]) or {}
+          except yaml.YAMLError as e:
+              print(f"ERROR: Front matter is invalid YAML after writeback: {e}", file=sys.stderr)
+              sys.exit(1)
+
+          sj = fm.get('skilljar', {}) or {}
+          if not sj.get('lesson_id', '').strip():
+              print(f"ERROR: skilljar.lesson_id not found in {qmd_file} after writeback", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"Front matter validation passed: skilljar.lesson_id = {sj['lesson_id']!r}")
+          PYEOF
+
       - name: Cleanup old ZIP files from gh-pages
         if: always()
         run: |

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -49,21 +49,36 @@ jobs:
                       print(f"Skipping {f}: no YAML front matter found")
                       continue
                   fm = yaml.safe_load(parts[1]) or {}
-                  course_id = str(fm.get('skilljar_course_id', '')).strip()
+
+                  # Support both nested skilljar: block (new) and flat
+                  # skilljar_* keys (deprecated).  Validation/warnings for
+                  # the deprecated form happen in R (parse_skilljar_fm()).
+                  sj = fm.get('skilljar', {}) or {}
+                  course_id = str(sj.get('course_id', '') or
+                                  fm.get('skilljar_course_id', '')).strip()
+
                   if course_id:
                       items.append({
                           'qmd_file': f,
                           'course_id': course_id,
                           'lesson_title': str(fm.get('title', f)),
-                          'package_title': str(fm.get('skilljar_package_title', '')),
+                          'package_title': str(
+                              sj.get('package_title', '') or
+                              fm.get('skilljar_package_title', '')),
                           'base_url': 'https://api.skilljar.com',
-                          'display_fullscreen': bool(fm.get('display_fullscreen', True)),
-                          'lesson_order': fm.get('skilljar_lesson_order', None),
-                          'lesson_id': str(fm.get('skilljar_lesson_id', '')),
+                          'display_fullscreen': bool(
+                              sj.get('display_fullscreen',
+                                     fm.get('display_fullscreen', True))),
+                          'lesson_order': (
+                              sj.get('lesson_order') or
+                              fm.get('skilljar_lesson_order')),
+                          'lesson_id': str(
+                              sj.get('lesson_id', '') or
+                              fm.get('skilljar_lesson_id', '')),
                       })
                       print(f"Added {f}: course_id={course_id!r}")
                   else:
-                      print(f"Skipping {f}: no skilljar_course_id in front matter")
+                      print(f"Skipping {f}: no skilljar.course_id in front matter")
               except Exception as e:
                   print(f"Warning: could not parse {f}: {e}")
 

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -339,6 +339,8 @@ jobs:
         env:
           QMD_FILE: ${{ matrix.qmd_file }}
         run: |
+          # Guard against silent ci_write_lesson_id() failure: if lesson_id is
+          # absent after writeback, the next run would create a duplicate lesson.
           python3 - << 'PYEOF'
           import yaml, os, re, sys
 

--- a/inst/workflows/publish-quarto-to-skilljar.yml
+++ b/inst/workflows/publish-quarto-to-skilljar.yml
@@ -149,9 +149,12 @@ jobs:
       - name: Check workflow version
         run: |
           # Extract the version recorded in this workflow file.
+          # NOTE: assumes the workflow file is installed under its default name.
+          # If the file was renamed, the grep returns empty and the "not found" warning fires.
           WORKFLOW_VERSION=$(grep -m1 'quarjar-workflow-version:' \
             "${GITHUB_WORKSPACE}/.github/workflows/publish-quarto-to-skilljar.yml" \
-            | sed 's/.*quarjar-workflow-version: *//')
+            | sed 's/.*quarjar-workflow-version:[[:space:]]*//' \
+            | tr -d '[:space:]')
 
           # Get the installed quarjar package version.
           PKG_VERSION=$(Rscript -e "cat(as.character(packageVersion('quarjar')))")

--- a/man/ci_write_lesson_id.Rd
+++ b/man/ci_write_lesson_id.Rd
@@ -16,19 +16,16 @@ ci_write_lesson_id(
 }
 \value{
 Invisibly returns \code{TRUE} if the file was modified,
-\code{FALSE} if \code{skilljar_lesson_id} was already present (file
-left unchanged).
+\code{FALSE} if the lesson ID was already present (file left unchanged).
 }
 \description{
-Reads a Quarto document, appends \code{skilljar_lesson_id} to the YAML
-front matter (if not already present), and writes the file back in place.
-This replaces the Python front-matter-patching script used in the
-"Write lesson ID back to main" workflow step, eliminating the Python
-dependency for that step.
+Reads a Quarto document and inserts \code{lesson_id} inside the nested
+\code{skilljar:} front matter block.  Aborts if no \code{skilljar:} block is
+present — the file must be migrated to the nested format first.
 }
 \details{
 The function exits silently (returning \code{FALSE}) if
-\code{skilljar_lesson_id} is already present, so it is safe to call
+\code{skilljar.lesson_id} is already present, so it is safe to call
 idempotently.
 }
 \section{Environment variables}{
@@ -41,7 +38,6 @@ idempotently.
 
 \examples{
 \dontrun{
-# In a GitHub Actions step (shell: Rscript {0}):
 library(quarjar)
 ci_write_lesson_id()
 }

--- a/man/use_skilljar_workflow.Rd
+++ b/man/use_skilljar_workflow.Rd
@@ -46,21 +46,21 @@ Before using this workflow, you must:
 
 All workflow configuration is driven by YAML front matter in your \code{.qmd}
 files. The workflow scans every changed \code{.qmd} file on push and reads the
-following keys:
+following keys inside a single nested \verb{skilljar:} block:
 
 \describe{
-\item{\code{skilljar_course_id}}{\strong{Required.} The Skilljar course ID to publish
-the lesson to. Files without this key are silently skipped by the
-workflow.}
+\item{\code{skilljar.course_id}}{\strong{Required.} The Skilljar course ID to
+publish the lesson to. Files without this key are silently skipped.}
 \item{\code{title}}{The lesson title in Skilljar. Uses the standard Quarto
-\code{title} field (not \code{skilljar_}-prefixed).}
-\item{\code{skilljar_package_title}}{\emph{(Optional)} Title for the Skilljar web
-package. Defaults to the value of \code{title} when omitted.}
-\item{\code{skilljar_lesson_order}}{\emph{(Optional)} Zero-based integer that sets
+\code{title} field (not nested under \verb{skilljar:}).}
+\item{\code{skilljar.package_title}}{\emph{(Optional)} Title for the Skilljar web
+package. Defaults to \code{title} when omitted.}
+\item{\code{skilljar.lesson_order}}{\emph{(Optional)} Zero-based integer that sets
 the lesson's position in the course syllabus on \strong{first publish only}.
-Ignored on subsequent updates. When omitted, the next available order is
-detected automatically.}
-\item{\code{skilljar_lesson_id}}{The Skilljar lesson ID. \strong{Do not set this
+Ignored on updates. Auto-detected when omitted.}
+\item{\code{skilljar.display_fullscreen}}{\emph{(Optional)} Logical. Whether the
+lesson iframe is displayed full-screen in Skilljar. Defaults to \code{true}.}
+\item{\code{skilljar.lesson_id}}{The Skilljar lesson ID. \strong{Do not set this
 manually.} After the first successful publish the workflow commits this
 value back to \code{main} (tagged \verb{[skip ci]}), switching future runs to the
 update-existing-lesson path.}
@@ -70,7 +70,8 @@ A minimal front matter example:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{---
 title: "My Lesson Title"
-skilljar_course_id: "abc123"
+skilljar:
+  course_id: "abc123"
 ---
 }\if{html}{\out{</div>}}
 
@@ -78,11 +79,18 @@ A fully configured example:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{---
 title: "Module 1: Getting Started"
-skilljar_course_id: "abc123"
-skilljar_package_title: "Module 1 Package"
-skilljar_lesson_order: 0
+skilljar:
+  course_id: "abc123"
+  package_title: "Module 1 Package"
+  lesson_order: 0
+  display_fullscreen: true
 ---
 }\if{html}{\out{</div>}}
+
+\strong{Deprecated flat keys:} \code{skilljar_course_id}, \code{skilljar_package_title},
+\code{skilljar_lesson_order}, \code{skilljar_lesson_id}, and \code{display_fullscreen} as
+top-level keys still work but will emit a deprecation warning at publish
+time. Migrate to the nested \verb{skilljar:} block at your earliest convenience.
 
 For complete setup instructions and troubleshooting, see the
 \href{https://github.com/posit-dev/quarjar/blob/main/examples/GITHUB_ACTION_SETUP.md}{setup guide}.

--- a/man/use_skilljar_workflow.Rd
+++ b/man/use_skilljar_workflow.Rd
@@ -38,22 +38,54 @@ Before using this workflow, you must:
 \enumerate{
 \item Enable GitHub Pages in your repository (Settings → Pages → Deploy from \code{gh-pages} branch)
 \item Add your Skilljar API key as a repository secret named \code{SKILLJAR_API_KEY}
+\item Add a fine-grained PAT with Contents and Pages read/write as a repository secret named \code{REPO_PAT}
 \item Set repository permissions to "Read and write" (Settings → Actions → General)
 }
 
-\strong{Usage:}
+\strong{Quarto Front Matter Keys:}
 
-After running this function, trigger the workflow from the Actions tab in your
-GitHub repository with the following inputs:
-\itemize{
-\item \code{qmd-file}: Path to your Quarto (.qmd) file
-\item \code{course-id}: Your Skilljar course ID
-\item \code{lesson-title}: Title for the lesson
-\item \code{package-title}: (optional) Title for the web package
+All workflow configuration is driven by YAML front matter in your \code{.qmd}
+files. The workflow scans every changed \code{.qmd} file on push and reads the
+following keys:
+
+\describe{
+\item{\code{skilljar_course_id}}{\strong{Required.} The Skilljar course ID to publish
+the lesson to. Files without this key are silently skipped by the
+workflow.}
+\item{\code{title}}{The lesson title in Skilljar. Uses the standard Quarto
+\code{title} field (not \code{skilljar_}-prefixed).}
+\item{\code{skilljar_package_title}}{\emph{(Optional)} Title for the Skilljar web
+package. Defaults to the value of \code{title} when omitted.}
+\item{\code{skilljar_lesson_order}}{\emph{(Optional)} Zero-based integer that sets
+the lesson's position in the course syllabus on \strong{first publish only}.
+Ignored on subsequent updates. When omitted, the next available order is
+detected automatically.}
+\item{\code{skilljar_lesson_id}}{The Skilljar lesson ID. \strong{Do not set this
+manually.} After the first successful publish the workflow commits this
+value back to \code{main} (tagged \verb{[skip ci]}), switching future runs to the
+update-existing-lesson path.}
 }
 
+A minimal front matter example:
+
+\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{---
+title: "My Lesson Title"
+skilljar_course_id: "abc123"
+---
+}\if{html}{\out{</div>}}
+
+A fully configured example:
+
+\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{---
+title: "Module 1: Getting Started"
+skilljar_course_id: "abc123"
+skilljar_package_title: "Module 1 Package"
+skilljar_lesson_order: 0
+---
+}\if{html}{\out{</div>}}
+
 For complete setup instructions and troubleshooting, see the
-\href{https://github.com/posit-dev/quarjar/blob/main/GITHUB_ACTION_SETUP.md}{setup guide}.
+\href{https://github.com/posit-dev/quarjar/blob/main/examples/GITHUB_ACTION_SETUP.md}{setup guide}.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -139,3 +139,27 @@ test_that("ci_write_lesson_id is idempotent when flat skilljar_lesson_id already
   result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_new")
   expect_false(result)  # already present, no changes
 })
+
+test_that("ci_write_lesson_id writes flat key with warning when no skilljar: block", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(c(
+    "---",
+    "title: Old style",
+    "skilljar_course_id: \"abc123\"",
+    "---",
+    "",
+    "Body."
+  ), tmp)
+  withr::defer(unlink(tmp))
+
+  w <- testthat::capture_warnings(
+    result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_fallback")
+  )
+  expect_true(result)
+  expect_match(w, "skilljar_lesson_id", all = FALSE)
+
+  lines <- readLines(tmp, warn = FALSE)
+  expect_true(any(grepl("^skilljar_lesson_id: \"les_fallback\"", lines)))
+  # must not have written an indented key
+  expect_false(any(grepl("^  lesson_id:", lines)))
+})

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -58,18 +58,17 @@ test_that("parse_skilljar_fm warns on non-logical display_fullscreen", {
   expect_warning(parse_skilljar_fm(fm), "display_fullscreen")
 })
 
-test_that("parse_skilljar_fm warns and promotes flat keys (compat shim)", {
+test_that("parse_skilljar_fm aborts on flat keys with migration message", {
   fm <- list(
     title = "My Lesson",
     skilljar_course_id = "flat123",
     display_fullscreen = FALSE
   )
-  w <- testthat::capture_warnings(
-    result <- parse_skilljar_fm(fm)
+  expect_error(
+    parse_skilljar_fm(fm),
+    regexp = "flat.*skilljar_\\*|deprecated|migrate",
+    ignore.case = TRUE
   )
-  expect_match(w, "deprecated", all = FALSE)
-  expect_equal(result$course_id, "flat123")
-  expect_false(result$display_fullscreen)
 })
 
 test_that("parse_skilljar_fm returns NULL when neither nested nor flat keys present", {
@@ -123,43 +122,49 @@ test_that("ci_write_lesson_id is idempotent when lesson_id already present (nest
   expect_true(any(grepl("les_existing", lines)))
 })
 
-test_that("ci_write_lesson_id is idempotent when flat skilljar_lesson_id already present", {
+
+test_that("ci_write_lesson_id aborts when no skilljar: block present", {
   tmp <- tempfile(fileext = ".qmd")
   writeLines(c(
     "---",
     "title: Old style",
     "skilljar_course_id: \"abc123\"",
-    "skilljar_lesson_id: \"les_old\"",
     "---",
     "",
     "Body."
   ), tmp)
   withr::defer(unlink(tmp))
 
-  result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_new")
-  expect_false(result)  # already present, no changes
+  expect_error(
+    ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_fail"),
+    regexp = "skilljar:.*block|nested|migrate",
+    ignore.case = TRUE
+  )
 })
 
-test_that("ci_write_lesson_id writes flat key with warning when no skilljar: block", {
+test_that("ci_write_lesson_id handles skilljar: block with no children", {
+  # Edge case: skilljar: is the last line of front matter (no indented children).
+  # seq_len(0) must return integer(0) so the for loop never executes,
+  # and lesson_id is appended right after the skilljar: line.
   tmp <- tempfile(fileext = ".qmd")
   writeLines(c(
     "---",
-    "title: Old style",
-    "skilljar_course_id: \"abc123\"",
+    "title: Test",
+    "skilljar:",
     "---",
     "",
     "Body."
   ), tmp)
   withr::defer(unlink(tmp))
 
-  w <- testthat::capture_warnings(
-    result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_fallback")
-  )
+  result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_edge")
   expect_true(result)
-  expect_match(w, "skilljar_lesson_id", all = FALSE)
 
   lines <- readLines(tmp, warn = FALSE)
-  expect_true(any(grepl("^skilljar_lesson_id: \"les_fallback\"", lines)))
-  # must not have written an indented key
-  expect_false(any(grepl("^  lesson_id:", lines)))
+  expect_true(any(grepl("^  lesson_id: \"les_edge\"", lines)))
+  # lesson_id must appear between the skilljar: line and the closing ---
+  sj_idx     <- which(grepl("^skilljar:\\s*$", lines))
+  end_idx    <- which(grepl("^---\\s*$", lines))[[2]]
+  lesson_idx <- which(grepl("^  lesson_id:", lines))
+  expect_true(lesson_idx > sj_idx && lesson_idx < end_idx)
 })

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -76,3 +76,66 @@ test_that("parse_skilljar_fm returns NULL when neither nested nor flat keys pres
   fm <- list(title = "Just a Quarto doc", format = "html")
   expect_null(parse_skilljar_fm(fm))
 })
+
+test_that("ci_write_lesson_id inserts lesson_id into nested skilljar block", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(c(
+    "---",
+    "title: Test",
+    "skilljar:",
+    "  course_id: \"abc123\"",
+    "---",
+    "",
+    "Body text."
+  ), tmp)
+  withr::defer(unlink(tmp))
+
+  result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_999")
+  expect_true(result)
+
+  lines <- readLines(tmp, warn = FALSE)
+  # lesson_id should appear inside the skilljar block (indented with 2 spaces)
+  expect_true(any(grepl("^  lesson_id: \"les_999\"", lines)))
+  # and NOT as a bare top-level key
+  expect_false(any(grepl("^skilljar_lesson_id:", lines)))
+  expect_false(any(grepl("^lesson_id:", lines)))
+})
+
+test_that("ci_write_lesson_id is idempotent when lesson_id already present (nested)", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(c(
+    "---",
+    "title: Test",
+    "skilljar:",
+    "  course_id: \"abc123\"",
+    "  lesson_id: \"les_existing\"",
+    "---",
+    "",
+    "Body."
+  ), tmp)
+  withr::defer(unlink(tmp))
+
+  result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_new")
+  expect_false(result)  # file unchanged
+
+  lines <- readLines(tmp, warn = FALSE)
+  expect_false(any(grepl("les_new", lines)))
+  expect_true(any(grepl("les_existing", lines)))
+})
+
+test_that("ci_write_lesson_id is idempotent when flat skilljar_lesson_id already present", {
+  tmp <- tempfile(fileext = ".qmd")
+  writeLines(c(
+    "---",
+    "title: Old style",
+    "skilljar_course_id: \"abc123\"",
+    "skilljar_lesson_id: \"les_old\"",
+    "---",
+    "",
+    "Body."
+  ), tmp)
+  withr::defer(unlink(tmp))
+
+  result <- ci_write_lesson_id(qmd_file = tmp, lesson_id = "les_new")
+  expect_false(result)  # already present, no changes
+})

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -64,11 +64,10 @@ test_that("parse_skilljar_fm warns and promotes flat keys (compat shim)", {
     skilljar_course_id = "flat123",
     display_fullscreen = FALSE
   )
-  result <- withCallingHandlers(
-    parse_skilljar_fm(fm),
-    warning = function(w) invokeRestart("muffleWarning")
+  w <- testthat::capture_warnings(
+    result <- parse_skilljar_fm(fm)
   )
-  expect_warning(parse_skilljar_fm(fm), "deprecated")
+  expect_match(w, "deprecated", all = FALSE)
   expect_equal(result$course_id, "flat123")
   expect_false(result$display_fullscreen)
 })

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -4,3 +4,76 @@ test_that("parse_skilljar_fm returns NULL when skilljar key is absent", {
   fm <- list(title = "My Lesson", other_key = "foo")
   expect_null(parse_skilljar_fm(fm))
 })
+
+test_that("parse_skilljar_fm returns typed list for valid nested input", {
+  fm <- list(
+    title = "My Lesson",
+    skilljar = list(
+      course_id    = "abc123",
+      lesson_order = 2L
+    )
+  )
+  result <- parse_skilljar_fm(fm)
+  expect_equal(result$course_id, "abc123")
+  expect_equal(result$lesson_order, 2L)
+  expect_equal(result$package_title, "")
+  expect_equal(result$lesson_id, "")
+  expect_true(result$display_fullscreen)  # default
+})
+
+test_that("parse_skilljar_fm aborts when course_id is missing", {
+  fm <- list(skilljar = list(package_title = "Foo"))
+  expect_error(parse_skilljar_fm(fm), "course_id.*required")
+})
+
+test_that("parse_skilljar_fm aborts when course_id is empty string", {
+  fm <- list(skilljar = list(course_id = ""))
+  expect_error(parse_skilljar_fm(fm), "course_id.*required")
+})
+
+test_that("parse_skilljar_fm aborts when course_id is numeric", {
+  fm <- list(skilljar = list(course_id = 123))
+  expect_error(parse_skilljar_fm(fm), "course_id.*character")
+})
+
+test_that("parse_skilljar_fm warns on unknown keys", {
+  fm <- list(skilljar = list(course_id = "abc123", corse_id = "typo"))
+  expect_warning(parse_skilljar_fm(fm), "Unknown key")
+})
+
+test_that("parse_skilljar_fm aborts when lesson_order is non-integer string", {
+  fm <- list(skilljar = list(course_id = "abc123", lesson_order = "two"))
+  expect_error(parse_skilljar_fm(fm), "lesson_order.*integer")
+})
+
+test_that("parse_skilljar_fm coerces numeric lesson_order to integer", {
+  fm <- list(skilljar = list(course_id = "abc123", lesson_order = 3.0))
+  result <- parse_skilljar_fm(fm)
+  expect_equal(result$lesson_order, 3L)
+  expect_type(result$lesson_order, "integer")
+})
+
+test_that("parse_skilljar_fm warns on non-logical display_fullscreen", {
+  fm <- list(skilljar = list(course_id = "abc123", display_fullscreen = "yes"))
+  expect_warning(parse_skilljar_fm(fm), "display_fullscreen")
+})
+
+test_that("parse_skilljar_fm warns and promotes flat keys (compat shim)", {
+  fm <- list(
+    title = "My Lesson",
+    skilljar_course_id = "flat123",
+    display_fullscreen = FALSE
+  )
+  result <- withCallingHandlers(
+    parse_skilljar_fm(fm),
+    warning = function(w) invokeRestart("muffleWarning")
+  )
+  expect_warning(parse_skilljar_fm(fm), "deprecated")
+  expect_equal(result$course_id, "flat123")
+  expect_false(result$display_fullscreen)
+})
+
+test_that("parse_skilljar_fm returns NULL when neither nested nor flat keys present", {
+  fm <- list(title = "Just a Quarto doc", format = "html")
+  expect_null(parse_skilljar_fm(fm))
+})

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,0 +1,6 @@
+# tests/testthat/test-ci.R
+
+test_that("parse_skilljar_fm returns NULL when skilljar key is absent", {
+  fm <- list(title = "My Lesson", other_key = "foo")
+  expect_null(parse_skilljar_fm(fm))
+})


### PR DESCRIPTION
## Summary

- Replaces the flat `skilljar_course_id` / `skilljar_lesson_id` / … front matter keys with a single nested `skilljar:` block, giving cleaner YAML and a single namespace for all Skilljar configuration
- Adds `parse_skilljar_fm()` internal helper with strict validation (aborts on flat keys, unknown keys, wrong types) and full unit-test coverage (16 tests)
- Updates `ci_write_lesson_id()` to patch the nested block surgically (text-based, no YAML round-trip); aborts when no `skilljar:` block present
- Bumps version to **0.2.0**

### Follow-up improvements (also in this PR)

- GHA detect block simplified to nested-only format; `lesson_order=0` falsy-Python bug fixed
- Workflow version header (`# quarjar-workflow-version: 0.2.0`) + runtime warn-only version check step
- Post-writeback YAML validation step guards against duplicate lesson creation
- README, `use_skilljar_workflow()` docs, and NEWS.md updated throughout

## Test Plan

- [ ] `devtools::test()` — 96 tests, 0 failures
- [ ] `devtools::check()` — 0 errors, 0 warnings
- [ ] Verify nested `skilljar:` front matter block is accepted end-to-end
- [ ] Verify flat `skilljar_*` keys produce an informative abort message
- [ ] Verify workflow version comment appears in installed workflow file